### PR TITLE
WIP: Add scope to data payload in token refresh

### DIFF
--- a/src/osdu/identity/_credential/token.py
+++ b/src/osdu/identity/_credential/token.py
@@ -101,6 +101,7 @@ class OsduTokenCredential(OsduBaseCredential):
             "refresh_token": self._refresh_token,
             "client_id": self._client_id,
             "client_secret": self._client_secret,
+            "scope": "openid email",
         }
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
         data = urlencode(body).encode("utf8")


### PR DESCRIPTION
I could not authenticate against my OSDU instance (using AWS Cognito) unless I added the `scope=openid email` bit to the data payload on the refresh token call.
I don't think hardcoding this is a good idea, or if adding this to the paylod will affect other IDPs, but raising this PR for awareness
 